### PR TITLE
Add `calculate_lesson_time` module

### DIFF
--- a/src/calculate_lesson_time.py
+++ b/src/calculate_lesson_time.py
@@ -1,2 +1,12 @@
-def calculate_lesson_time():
-    return
+def calculate_lesson_time(num_of_entrants, allocated_time):
+    num_of_entrants = float(num_of_entrants)
+    allocated_time = float(allocated_time)
+
+    performance_time = num_of_entrants * allocated_time
+    adjudication_time = performance_time * 0.4
+    changover_time = num_of_entrants * 0.1
+    lesson_time = round(
+        (performance_time + adjudication_time + changover_time) / 5
+    ) * 5
+
+    return lesson_time

--- a/src/calculate_lesson_time.py
+++ b/src/calculate_lesson_time.py
@@ -1,0 +1,2 @@
+def calculate_lesson_time():
+    return

--- a/test/test_calculate_lesson_time.py
+++ b/test/test_calculate_lesson_time.py
@@ -1,0 +1,14 @@
+import pytest
+
+from src.calculate_lesson_time import calculate_lesson_time
+
+
+@pytest.mark.xfail
+class TestCalculateLessonTime():
+    @pytest.mark.parametrize(
+        "entries, allocated_time, expected",
+        [(10, 5, 70), (6, 8, 70), (3, 12, 50), (0, 5, 0)],
+    )
+    def test_calculate_lesson_time(self, entries, allocated_time, expected):
+        result = calculate_lesson_time(entries, allocated_time)
+        assert result == expected

--- a/test/test_calculate_lesson_time.py
+++ b/test/test_calculate_lesson_time.py
@@ -3,7 +3,6 @@ import pytest
 from src.calculate_lesson_time import calculate_lesson_time
 
 
-@pytest.mark.xfail
 class TestCalculateLessonTime():
     @pytest.mark.parametrize(
         "entries, allocated_time, expected",


### PR DESCRIPTION
`calculate_lesson_time` uses the number of entrants (`num_of_entrants`) and the maximum allocated performance time (`allocated_time`) to estimate how long the class should be in minutes, rounded to the nearest 5.